### PR TITLE
add npm install to initial msg

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -102,6 +102,7 @@ module.exports = function (values) {
 To get started:
 
   cd {{projectName}}
+  npm install
   npm run format
   npm run lint
   npm run test


### PR DESCRIPTION
When creating a new microservice (`micro-ab`) using the template, I get the following message:
```
cd micro-ab
npm run format
npm run lint
npm run test
npm run dev
```
However, `npm run format` fails because you have not installed your modules :-) See below:
```
 $ moleculer init --no-install "bytetechnology/micro-service-template" micro-ab
Template repo: bytetechnology/micro-service-template
Downloading template...
? Does your service need to access a database No
Create 'micro-ab' folder...


   To get started:

     cd micro-ab
     npm run format
     npm run lint
     npm run test
     npm run dev



 ~                                                                                                                                  ✔  1388  15:58:29
 $ cd micro-ab

 ~/micro-ab                                                                                                                         ✔  1389  15:58:38
 $ npm run format

> micro-ab@0.0.1 format /Users/abuznego/micro-ab
> prettier --write "{src,{tests,mocks}}/**/*.{js,ts}"

sh: prettier: command not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! micro-ab@0.0.1 format: `prettier --write "{src,{tests,mocks}}/**/*.{js,ts}"`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the micro-ab@0.0.1 format script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/abuznego/.npm/_logs/2020-04-03T22_58_42_224Z-debug.log
```

This PR adds a message to `npm install` before any `npm run X` 