### PR TITLE
add test for calling startServiceAndBroker() when already started

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -96,7 +96,7 @@
         "tsConfig": "tsconfig.json"
       }
     },
-    "testTimeout": 20000,
+    "testTimeout": 30000,
     "setupFilesAfterEnv": [
       "./tests/setup.ts"
     ],

--- a/template/tests/lib/start.service.and.broker.spec.ts
+++ b/template/tests/lib/start.service.and.broker.spec.ts
@@ -47,4 +47,22 @@ test('Call getService() before startServiceAndBroker() completed.', async () => 
   await broker.stop();
 });
 
+test('Call startServiceAndBroker() when already started => FAIL', async () => {
+  const { startServiceAndBroker, getService } = await import(
+    '../../src/lib/start.service.and.broker'
+  );
+  const { broker } = await import('../../src/lib/moleculer/broker');
+
+  const [, service] = await Promise.all([
+    startServiceAndBroker([]),
+    getService()
+  ]);
+
+  expect(startServiceAndBroker([])).rejects.toThrow();
+
+  // Clean up
+  await broker.destroyService(service);
+  await broker.stop();
+});
+
 export {};

--- a/template/tests/lib/start.service.and.broker.spec.ts
+++ b/template/tests/lib/start.service.and.broker.spec.ts
@@ -58,7 +58,7 @@ test('Call startServiceAndBroker() when already started => FAIL', async () => {
     getService()
   ]);
 
-  expect(startServiceAndBroker([])).rejects.toThrow();
+  await expect(startServiceAndBroker([])).rejects.toThrow();
 
   // Clean up
   await broker.destroyService(service);


### PR DESCRIPTION
On a fresh new micro service, coverage if 100%. However, when running on `micro-discount` line 50 is uncovered:
```
------------------------------|---------|----------|---------|---------|-------------------
File                          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------|---------|----------|---------|---------|-------------------
All files                     |   99.79 |    98.99 |     100 |   99.77 |                   
 src                          |     100 |      100 |     100 |     100 |                   
  db.connector.ts             |     100 |      100 |     100 |     100 |                   
  discount.service.ts         |     100 |      100 |     100 |     100 |                   
  env.schema.ts               |     100 |      100 |     100 |     100 |                   
  start.stop.all.ts           |     100 |      100 |     100 |     100 |                   
 src/action.handlers          |     100 |      100 |     100 |     100 |                   
  add.discount.ts             |     100 |      100 |     100 |     100 |                   
  get.discount.ts             |     100 |      100 |     100 |     100 |                   
  welcome.ts                  |     100 |      100 |     100 |     100 |                   
 src/api                      |     100 |      100 |     100 |     100 |                   
  api.utils.ts                |     100 |      100 |     100 |     100 |                   
  index.ts                    |     100 |      100 |     100 |     100 |                   
 src/api/params               |     100 |      100 |     100 |     100 |                   
  add.discount.params.ts      |     100 |      100 |     100 |     100 |                   
  get.discount.params.ts      |     100 |      100 |     100 |     100 |                   
  uuid.res.ts                 |     100 |      100 |     100 |     100 |                   
  welcome.params.ts           |     100 |      100 |     100 |     100 |                   
 src/entities                 |     100 |      100 |     100 |     100 |                   
  base.entity.ts              |     100 |      100 |     100 |     100 |                   
  discount.category.ts        |     100 |      100 |     100 |     100 |                   
  discount.coupon.ts          |     100 |      100 |     100 |     100 |                   
  discount.happy.hour.ts      |     100 |      100 |     100 |     100 |                   
  discount.shelf.life.ts      |     100 |      100 |     100 |     100 |                   
  discount.sku.ts             |     100 |      100 |     100 |     100 |                   
  discount.store.ts           |     100 |      100 |     100 |     100 |                   
  discount.transaction.ts     |     100 |      100 |     100 |     100 |                   
  discount.ts                 |     100 |      100 |     100 |     100 |                   
  happy.hour.day.ts           |     100 |      100 |     100 |     100 |                   
  index.ts                    |     100 |      100 |     100 |     100 |                   
 src/lib                      |   98.04 |    83.33 |     100 |   97.92 |                   
  env.base.schema.ts          |     100 |      100 |     100 |     100 |                   
  start.service.and.broker.ts |   97.22 |    83.33 |     100 |   97.14 | 50                
 src/lib/moleculer            |     100 |      100 |     100 |     100 |                   
  broker.ts                   |     100 |      100 |     100 |     100 |                   
 src/middlewares              |     100 |      100 |     100 |     100 |                   
  moleculer.db.middleware.ts  |     100 |      100 |     100 |     100 |                   
  moleculer.log.middleware.ts |     100 |      100 |     100 |     100 |                   
------------------------------|---------|----------|---------|---------|-------------------
```